### PR TITLE
"backup" as default command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ ENV DB_DUMP_POST_RESTORE_SCRIPTS="/scripts.d/post-restore/"
 
 # start
 ENTRYPOINT ["/entrypoint"]
+CMD ["backup"]


### PR DESCRIPTION
The previous version of the docker container required to explicitly define a command to be passed to /mysql-backup. This change makes "backup" the default behavior. Other commands as "restore" can be specified on runtime. This makes the container compatible with configurations of previous versions <1.0